### PR TITLE
fix: expression syntax error in portainer url

### DIFF
--- a/credentials/PortainerApi.credentials.ts
+++ b/credentials/PortainerApi.credentials.ts
@@ -53,7 +53,7 @@ export class PortainerApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			method: 'GET',
-			url: '={{$credentials.baseUrl.replace(/\/+$/, "")}}/api/users/me',
+			url: '={{$credentials.baseUrl.replace(new RegExp("/+$"), "")}}/api/users/me',
 			skipSslCertificateValidation: '={{$credentials.ignoreSsl}}',
 		},
 		rules: [

--- a/nodes/Portainer/Portainer.node.ts
+++ b/nodes/Portainer/Portainer.node.ts
@@ -84,7 +84,7 @@ export class Portainer implements INodeType {
 			},
 		],
 		requestDefaults: {
-			baseURL: '={{$credentials.baseUrl.replace(/\/+$/, "")}}/api',
+			baseURL: '={{$credentials.baseUrl.replace(new RegExp("/+$"), "")}}/api',
 			skipSslCertificateValidation: '={{$credentials.ignoreSsl}}',
 			headers: {
 				Accept: 'application/json',


### PR DESCRIPTION
fix syntax error in https://github.com/ramonmatias19/n8n-nodes-portainer/issues/8